### PR TITLE
Fix high cpu usage

### DIFF
--- a/nester.nimble
+++ b/nester.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.1.0"
+version       = "0.1.1"
 author        = "Volodymyr Melnychuk"
 description   = "A new awesome nimble package"
 license       = "MIT"

--- a/src/nester.nim
+++ b/src/nester.nim
@@ -180,6 +180,5 @@ proc serve*(r: NesterRouter, p: Port = Port(5000), staticPath: string = "") =
 
             echo ">~", request.url.path, " ", request.body, " in ", formatFloat(epochTime() - t0, format = ffDecimal, precision = 3), "s"
 
-    while true:
-        if hasPendingOperations(): # avoid ValueError in case no operations are pending
-            drain(timeout = 0)
+    runForever()
+


### PR DESCRIPTION
Calling `drain` without timeout makes a tight loop, which happily consumes 100% cpu.